### PR TITLE
Add possibility to specify base image and build scripts.

### DIFF
--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -356,19 +356,23 @@ run_build() {
    
     ln -s "${TRAVIS_BUILD_DIR}/patch" "${SMALLTALK_CI_BUILD}/patch"
 
-    print_info "Loading build before script..."
-    for script_file in $( ls "${TRAVIS_BUILD_DIR}/build/before/" ); do
-      echo "Loading --- ${TRAVIS_BUILD_DIR}/build/before/${script_file}"
-      pharo::run_load_script "${TRAVIS_BUILD_DIR}/build/before/${script_file}"
-    done
+    print_info "Loading before build scripts..."
+    if [ -n "${SMALLTALK_CI_BEFORE_BUILD_SCRIPTS_FOLDER+set}" ]; then
+      for script_file in $( ls "${SMALLTALK_CI_BEFORE_BUILD_SCRIPTS_FOLDER}" ); do
+        echo "Loading --- ${SMALLTALK_CI_BEFORE_BUILD_SCRIPTS_FOLDER}/${script_file}"
+        pharo::run_load_script "${SMALLTALK_CI_BEFORE_BUILD_SCRIPTS_FOLDER}/${script_file}"
+      done
+    fi
 
     pharo::load_project
 
-    print_info "Loading build after script..."
-    for script_file in $( ls "${TRAVIS_BUILD_DIR}/build/after/" ); do
-      echo "Loading --- ${TRAVIS_BUILD_DIR}/build/after/${script_file}"
-      pharo::run_load_script "${TRAVIS_BUILD_DIR}/build/after/${script_file}"
-    done
+    print_info "Loading after build scripts..."
+    if [ -n "${SMALLTALK_CI_AFTER_BUILD_SCRIPTS_FOLDER+set}" ]; then
+      for script_file in $( ls "${SMALLTALK_CI_AFTER_BUILD_SCRIPTS_FOLDER}" ); do
+        echo "Loading --- ${SMALLTALK_CI_AFTER_BUILD_SCRIPTS_FOLDER}/${script_file}"
+        pharo::run_load_script "${SMALLTALK_CI_AFTER_BUILD_SCRIPTS_FOLDER}/${script_file}"
+      done
+    fi
 
     check_build_status
   fi

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -190,7 +190,7 @@ pharo::prepare_image() {
 
   if [ -n "${SMALLTALK_CI_BASE_IMAGE_FOLDER+set}" ]; then
     # Use given image as base image
-    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}"/* "${target}/"
+    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/*" "${target}/"
   else
     # Download new base image
     local pharo_image_url="$(pharo::get_image_url "${smalltalk_name}")"

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -190,7 +190,8 @@ pharo::prepare_image() {
 
   if [ -n "${SMALLTALK_CI_BASE_IMAGE_FOLDER+set}" ]; then
     # Use given image as base image
-    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/*" "${target}/"
+    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.image "${target}/"
+    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.changes "${target}/"
   else
     # Download new base image
     local pharo_image_url="$(pharo::get_image_url "${smalltalk_name}")"

--- a/pharo/run.sh
+++ b/pharo/run.sh
@@ -190,8 +190,9 @@ pharo::prepare_image() {
 
   if [ -n "${SMALLTALK_CI_BASE_IMAGE_FOLDER+set}" ]; then
     # Use given image as base image
-    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.image "${target}/"
-    cp -r "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.changes "${target}/"
+    mkdir -p ${target}
+    cp "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.image "${target}/"
+    cp "${SMALLTALK_CI_BASE_IMAGE_FOLDER}/"*.changes "${target}/"
   else
     # Download new base image
     local pharo_image_url="$(pharo::get_image_url "${smalltalk_name}")"

--- a/run.sh
+++ b/run.sh
@@ -502,25 +502,6 @@ deploy() {
 
   print_info "Deploy..."
 
-  # if is_empty "${BINTRAY_CREDENTIALS:-}" || \
-  #     [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
-  #   return
-  # fi
-
-  # if [[ "${build_status}" -eq 0 ]]; then
-  #   if is_empty "${BINTRAY_RELEASE:-}" || \
-  #       [[ "${TRAVIS_BRANCH}" != "master" ]]; then
-  #     return
-  #   fi
-  #   target="${BINTRAY_API}/${BINTRAY_RELEASE}/${version}"
-  #   publish=true
-  # else
-  #   if is_empty "${BINTRAY_FAIL:-}"; then
-  #     return
-  #   fi
-  #   target="${BINTRAY_API}/${BINTRAY_FAIL}/${version}"
-  # fi
-
   travis_fold start deploy "Deploying to ..."
     timer_start
 
@@ -529,27 +510,7 @@ deploy() {
     print_info "Compressing image and changes files..."
     mv "${SMALLTALK_CI_IMAGE}" "${name}.image"
     mv "${SMALLTALK_CI_CHANGES}" "${name}.changes"
-    # tar czf "${name}.tar.gz" "${name}.image" "${name}.changes"
-    # curl -s -u "$BINTRAY_CREDENTIALS" -T "${name}.tar.gz" \
-    #     "${target}/${name}.tar.gz" > /dev/null
     zip -q "travis-${name}.zip" "${name}.image" "${name}.changes"
-    # curl -s -u "$BINTRAY_CREDENTIALS" -T "${name}.zip" \
-    #     "${target}/${name}.zip" > /dev/null
-    # if [[ "${build_status}" -ne 0 ]]; then
-    #   # Check for xml files and upload them
-    #   if ls *.xml 1> /dev/null 2>&1; then
-    #     print_info "Compressing and uploading debugging files..."
-    #     mv "${TRAVIS_BUILD_DIR}/"*.fuel "${SMALLTALK_CI_BUILD}/" || true
-    #     find . -name "*.xml" -o -name "*.fuel" | tar czf "debug.tar.gz" -T -
-    #     curl -s -u "$BINTRAY_CREDENTIALS" \
-    #         -T "debug.tar.gz" "${target}/" > /dev/null
-    #   fi
-    # fi
-
-    # if "${publish}"; then
-    #   print_info "Publishing ${version}..."
-    #   curl -s -X POST -u "$BINTRAY_CREDENTIALS" "${target}/publish" > /dev/null
-    # fi
 
     is_dir image || mkdir image
     cp "travis-${name}.zip" "image/travis-${name}.zip"

--- a/run.sh
+++ b/run.sh
@@ -493,9 +493,8 @@ uninstall_script() {
 deploy() {
   local build_status=$1
   local target
-  local version="${TRAVIS_BUILD_NUMBER}"
   local project_name="$(basename ${TRAVIS_BUILD_DIR})"
-  local name="${project_name}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}-${config_smalltalk}"
+  local name="${project_name}-${TRAVIS_COMMIT}-${config_smalltalk}"
   local image_name="${SMALLTALK_CI_BUILD}/${name}.image"
   local changes_name="${SMALLTALK_CI_BUILD}/${name}.changes"
   local publish=false


### PR DESCRIPTION
- Set SMALLTALK_CI_BASE_IMAGE_FOLDER to build from specific base image.
- Set SMALLTALK_CI_BEFORE_BUILD_SCRIPTS_FOLDER to build scripts before main build.
- Set SMALLTALK_CI_AFTER_BUILD_SCRIPTS_FOLDER to build scripts after main build.